### PR TITLE
add type-safety without having to add <generic> notation

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,14 +9,17 @@ import TextInputThree from "@/components/TextInputThree";
 import TextInputFour from "@/components/TextInputFour";
 import TextInputFive from "@/components/TextInputFive";
 import { FormField, FormItem, FormLabel, FormControl } from "@/components/Form";
+import { FormValuesProvider } from "@/components/FormValuesContext";
 
 const formSchema = z.object({
   firstName: z.string().min(2).max(50),
   lastName: z.string().min(2).max(50),
 });
 
+export type FormValues = z.infer<typeof formSchema>;
+
 export default function Home() {
-  type FormValues = z.infer<typeof formSchema>;
+  // type FormValues = z.infer<typeof formSchema>;
   const methods = useForm<FormValues>({
     resolver: zodResolver(formSchema),
     defaultValues: {
@@ -43,13 +46,13 @@ export default function Home() {
         {/* invalid name, ts doesn't catch it */}
         <TextInput name="bingBong" />
         {/* invalid name, ts catches it but requires this gross <FormValues> generic type */}
-        <TextInput<FormValues> name="bingBong" />
+        {/* <TextInput<FormValues> name="bingBong" /> */}
         {/* invalid name, ts doesn't catch it */}
         <TextInputTwo name="bingBong" />
         {/* invalid name, ts doesn't catch it */}
         <TextInputThree name="bingBong" />
         {/* invalid name, ts doesn't catch it */}
-        <TextInputFour fieldValues={FormValues} name="bingBong" />
+        {/* <TextInputFour fieldValues={FormValues} name="bingBong" /> */}
         {/* invalid name, ts doesn't catch it */}
         <TextInputFive name="bingBong" />
         {/* invalid name, ts catches it but requires redundently passing control */}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,7 +9,6 @@ import TextInputThree from "@/components/TextInputThree";
 import TextInputFour from "@/components/TextInputFour";
 import TextInputFive from "@/components/TextInputFive";
 import { FormField, FormItem, FormLabel, FormControl } from "@/components/Form";
-import { FormValuesProvider } from "@/components/FormValuesContext";
 
 const formSchema = z.object({
   firstName: z.string().min(2).max(50),

--- a/src/components/TextInput.tsx
+++ b/src/components/TextInput.tsx
@@ -1,3 +1,4 @@
+import { FormValues } from "@/app/page";
 import React from "react";
 import {
   FieldPath,
@@ -6,17 +7,41 @@ import {
   Controller,
 } from "react-hook-form";
 
-type TextInputProps<TFieldValues extends FieldValues> = {
-  name: FieldPath<TFieldValues>;
+// type TextInputProps<TFieldValues extends FieldValues> = {
+//   name: FieldPath<TFieldValues>;
+// };
+
+type TextInputProps = {
+  name: FieldPath<FormValues>;
 };
 
-const TextInput = <TFieldValues extends FieldValues>({
-  name,
-}: TextInputProps<TFieldValues>) => {
+// const TextInput = <TFieldValues extends FieldValues>({
+//   name,
+// }: TextInputProps<TFieldValues>) => {
+//   const {
+//     control,
+//     formState: { errors },
+//   } = useFormContext<TFieldValues>();
+
+//   return (
+//     <div>
+//       <Controller
+//         control={control}
+//         name={name}
+//         render={({ field: { onChange, value } }) => (
+//           <input type="text" onChange={onChange} value={value} />
+//         )}
+//       />
+//       {errors[name] && <p>{errors[name]?.message?.toString()}</p>}
+//     </div>
+//   );
+// };
+
+const TextInput = ({ name }: TextInputProps) => {
   const {
     control,
     formState: { errors },
-  } = useFormContext<TFieldValues>();
+  } = useFormContext();
 
   return (
     <div>

--- a/src/lib/useFormField.ts
+++ b/src/lib/useFormField.ts
@@ -1,0 +1,14 @@
+import { useFormContext, Controller, FieldPath } from "react-hook-form";
+import { FieldValues } from "react-hook-form";
+
+const useFormField = <TFieldValues extends FieldValues>(
+  name: FieldPath<TFieldValues>
+) => {
+  const {
+    control,
+    formState: { errors },
+  } = useFormContext<TFieldValues>();
+  return { control, error: errors[name] };
+};
+
+export default useFormField;


### PR DESCRIPTION
in the TextInput I just check if the name attribute follows the type declared at:
export type FormValues = z.infer<typeof formSchema>;